### PR TITLE
feat: add unmodified enumStyle option

### DIFF
--- a/ng-openapi-gen-schema.json
+++ b/ng-openapi-gen-schema.json
@@ -124,12 +124,13 @@
       ]
     },
     "enumStyle": {
-      "description": "Determines how root enums will be generated. Possible values are:\n\n- `alias`: just generate a type alias with the possible values;\n- `upper` for an enum with UPPER_CASE names, and;\n- `pascal` for enum PascalCase names. Defaults to 'pascal'.",
+      "description": "Determines how root enums will be generated. Possible values are:\n\n- `alias`: just generate a type alias with the possible values;\n- `upper` for an enum with UPPER_CASE names;\n- `pascal` for enum PascalCase names;\n- `unmodified` to use the value as the name after basic character parsing; Defaults to 'pascal'.",
       "default": "pascal",
       "enum": [
         "alias",
         "upper",
-        "pascal"
+        "pascal",
+        "unmodified"
       ]
     },
     "templates": {

--- a/src/gen-utils.ts
+++ b/src/gen-utils.ts
@@ -25,7 +25,9 @@ export function typeName(name: string): string {
  */
 export function enumName(value: string, options: Options): string {
   const name = toBasicChars(value, true);
-  if (options.enumStyle === 'upper') {
+  if (options.enumStyle === 'unmodified') {
+    return name;
+  } else if (options.enumStyle === 'upper') {
     return upperCase(name).replace(/\s+/g, '_');
   } else {
     return upperFirst(camelCase(name));

--- a/src/options.ts
+++ b/src/options.ts
@@ -61,12 +61,13 @@ export interface Options {
    * Determines how root enums will be generated. Possible values are:
    *
    * - `alias`: just generate a type alias with the possible values;
-   * - `upper` for an enum with UPPER_CASE names, and;
-   * - `pascal` for enum PascalCase names.
+   * - `upper` for an enum with UPPER_CASE names;
+   * - `pascal` for enum PascalCase names;
+   * - `unmodified` to use the value as the name after basic character parsing;
    *
    * Defaults to 'pascal'.
    */
-  enumStyle?: 'alias' | 'upper' | 'pascal';
+  enumStyle?: 'alias' | 'upper' | 'pascal' | 'unmodified';
 
   /** Custom templates directory. Any `.handlebars` files here will be used instead of the corresponding default. */
   templates?: string;


### PR DESCRIPTION
This pull request adds an `unmodified` option to `enumStyle` to use the values as the names after only basic character parsing.

This can be used to fix https://code.siemens.com/tg/tgw/-/issues/571